### PR TITLE
set the string encoding on ruby 1.9

### DIFF
--- a/lib/geoip.rb
+++ b/lib/geoip.rb
@@ -782,6 +782,8 @@ class GeoIP
         # Get the city:
         city = spl[1]
         @iter_pos += (city.size + 1) unless @iter_pos.nil?
+        # set the correct encoding in ruby 1.9 compatible environments:
+        city.force_encoding('iso-8859-1') if city.respond_to?(:force_encoding)
 
         # Get the postal code:
         postal_code = spl[2]


### PR DESCRIPTION
City names in the db file appear to be encoded as iso-8859-1. My change does not affect the bytes of the string returned, it just marks the city name as iso-8859-1 so that it can be transcoded with city.encode('utf-8') for example. The return value on ruby 1.8 is not affected by this change.

Tested with:
GeoIP.new(...).city('www.jyu.fi')[7] # => Jyväskylä
(Terminal settings affect how it looks in irb but it should look correct when included in a web page with the same encoding.)
