### PR TITLE
GeoIP::Result with hash access, backwards compatible.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,19 +16,29 @@ This release adds support for timezone names, thanks to Tonni Aagesen.
 == SYNOPSIS:
 
   require 'geoip'
-  GeoIP.new('GeoLiteCity.dat').country('www.atlantis.sk')
-  => ["www.atlantis.sk", "217.67.18.26", "SK", "SVK", "Slovakia", "EU", "02", "Bratislava", "", 48.15, 17.1167, nil, nil, "Europe/Bratislava"]
+  result = GeoIP.new('GeoIP.dat').country('www.atlantis.sk')
+  => {:hostname=>"www.atlantis.sk", :ip=>"217.67.18.26", :country_code=>196, :country_alpha2=>"SK", :country_alpha3=>"SVK", :country_name=>"Slovakia", :continent=>"EU"}
+  result.to_a
+  => ["www.atlantis.sk", "217.67.18.26", 196, "SK", "SVK", "Slovakia", "EU"]
 
   Returned values are the requested hostname, the IP address as a dotted quad,
-  Maxmind's country code, the ISO 3166-1 alpha-2 country code, the ISO 3166-1 alpha-3 country code,
-  the ISO 3166 country name, and the continent code.
+  Maxmind's country code, the ISO 3166-1 alpha-2 country code,
+  the ISO 3166-1 alpha-3 country code, the ISO 3166 country name, and the continent code.
+  Note that if a city database (like GeoLiteCity.dat) is used, this method
+  delegates to the country method.
 
-  GeoIP.new('GeoCity.dat').city('github.com')
-  => ["github.com", "207.97.227.239", "US", "USA", "United States", "NA", "CA", "San Francisco", "94110", 37.7484, -122.4156, 807, 415, "America/Los_Angeles"]
+  result = GeoIP.new('GeoCity.dat').city('github.com')
+  => {:hostname=>"github.com", :ip=>"207.97.227.239", :country_alpha2=>"US", :country_alpha3=>"USA", :country_name=>"United States", :continent=>"NA", :region=>"TX", :city=>"San Antonio", :postal_code=>"78229", :latitude=>29.5072, :longitude=>-98.5748, :us_dma_code=>641, :us_area_code=>210, :timezone=>"America/Chicago"}
+  result.to_a
+  => ["github.com", "207.97.227.239", "US", "USA", "United States", "NA", "TX", "San Antonio", "78229", 29.5072, -98.5748, 641, 210, "America/Chicago"]
 
-  Returned values are the country values followed by region or state name,
-  city name, postal_code/zipcode, latitude, longitude, USA DMA code, USA area code,
-  timezone name. Sorry it's not a Hash... historical.
+  Returned values are the country values (except Maxmind's country code) followed
+  by region or state name, city name, postal_code/zipcode, latitude, longitude,
+  USA DMA code, USA area code, timezone name.
+
+  For backwards compatibility, results from #country and #city can be accessed by
+  their hash key, or by their numeric index.
+  So result[:country_name] is equivalent to result[4].
 
   GeoIP.new('GeoIPASNum.dat').asn("www.fsb.ru")
   => ["AS8342", "RTComm.RU Autonomous System"]

--- a/test/test_geoip.rb
+++ b/test/test_geoip.rb
@@ -8,4 +8,25 @@ class TestGeoip < Test::Unit::TestCase
   def test_truth
     assert true
   end
+
+  def test_geoip_result
+    result = GeoIP::Result[[
+      [:a, "a"],
+      [:b, "b"],
+      [:c, "c"]
+    ]]
+
+    # hash access
+    assert_equal "a", result[:a]
+    assert_equal "b", result[:b]
+    assert_equal "c", result[:c]
+
+    # numeric array access
+    assert_equal "a", result[0]
+    assert_equal "b", result[1]
+    assert_equal "c", result[2]
+
+    # Result#to_a
+    assert_equal %w{a b c}, result.to_a
+  end
 end


### PR DESCRIPTION
G'day Cliff,

The `#country` and `#city` methods now return `GeoIP::Result`, which subclasses `Hash`, adding support for numeric array access for GeoIP backwards compatibility.

```
result = GeoIP.new("/usr/share/GeoIP/GeoIPCity.dat").city("github.com")
 => {:hostname=>"github.com", :ip=>"207.97.227.239", :country_alpha2=>"US", :country_alpha3=>"USA", :country_name=>"United States", :continent=>"NA", :region=>"TX", :city=>"San Antonio", :postal_code=>"78229", :latitude=>29.50720000000001, :longitude=>-98.5748, :us_dma_code=>641, :us_area_code=>210, :timezone=>"America/Chicago"}

# nice hash access
result[:country_name]
 => "United States"

# backwards compatible
result[4]
 => "United States"

# the complete old-style array
result.to_a
 => ["github.com", "207.97.227.239", "US", "USA", "United States", "NA", "TX", "San Antonio", "78229", 29.50720000000001, -98.5748, 641, 210, "America/Chicago"]
```

Tested in ruby-1.9.2, plus ruby-1.8.7 to verify there are no Hash ordering problems, plus jruby-1.5.6 just for good measure.

I've also fixed a few inconsistencies in the documentation, regarding ISO 3166-1 alpha-2 and alpha-3 codes, and what values are included in responses - the `#city` method doesn't actually return the Maxmind numeric country code.

Hopefully these changes suit you - I think hash access like `result[:country_name]` rather than `result[4]` will make code using GeoIP much easier to read and understand.  As far as I can tell it's fully backwards compatible, although it'd be nice to have a test suite to be sure ;)

Cheers!
Paul
