### PR TITLE
Allow GEOIP_ORG_EDITION database to call GeoIP#isp

### DIFF
--- a/lib/geoip.rb
+++ b/lib/geoip.rb
@@ -827,7 +827,8 @@ class GeoIP
 
         # Convert numeric IP address to an integer
         ipnum = iptonum(ip)
-        if @databaseType != GEOIP_ISP_EDITION
+        if (@databaseType != GEOIP_ISP_EDITION &&
+            @databaseType != GEOIP_ORG_EDITION)
             throw "Invalid GeoIP database type, can't look up Organization/ISP by IP"
         end
         pos = seek_record(ipnum);


### PR DESCRIPTION
I have a Maxmind Organization database that we bought, and calling the isp method on it failed for "wrong database type". I found out that it simply works if I allow the GEOP_ORG_EDITION database type in that method.
