### PR TITLE
don't explode while each-ing if a postal_code is nil

### DIFF
--- a/lib/geoip.rb
+++ b/lib/geoip.rb
@@ -443,7 +443,7 @@ class GeoIP
 
     # Get the postal code:
     postal_code = spl[2]
-    @iter_pos += (postal_code.size + 1) unless @iter_pos.nil?
+    @iter_pos += (postal_code.size + 1) unless @iter_pos.nil? || postal_code.nil?
 
     record = spl[3]
 


### PR DESCRIPTION
Hi. On our version of the GeoIPCity file, each-ing over the cities would raise an error because a postal_code on one of the cities was nil. I've added a guard clause to protect against that.
