### PR TITLE
Add option to set a local IP substitute

### DIFF
--- a/lib/geoip.rb
+++ b/lib/geoip.rb
@@ -138,7 +138,7 @@ class GeoIP
   attr_reader :database_type
 
   # An IP that is used instead of local IPs
-  attr_accessor :local_ip
+  attr_accessor :local_ip_alias
 
   alias databaseType database_type
 
@@ -503,8 +503,8 @@ class GeoIP
   end
 
   def lookup_ip(ip_or_hostname) # :nodoc:
-    if is_local?(ip_or_hostname) && @local_ip
-      ip_or_hostname = @local_ip
+    if is_local?(ip_or_hostname) && @local_ip_alias
+      ip_or_hostname = @local_ip_alias
     end
 
     if !ip_or_hostname.kind_of?(String) or ip_or_hostname =~ /^[0-9.]+$/
@@ -517,8 +517,8 @@ class GeoIP
     ip
   end
 
-  def is_local?(ip_or_hostname) #:nodoc
-    ["127.0.0.1", "localhost"].include? ip_or_hostname
+  def is_local?(ip_or_hostname) #:nodoc:
+    ["127.0.0.1", "localhost", "::1", "0000::1", "0:0:0:0:0:0:0:1"].include? ip_or_hostname
   end
 
   # Convert numeric IP address to Integer.


### PR DESCRIPTION
I'm using this feature which is quite handy in development mode. Basically it allows your app to have sensible data while running on your local (development) machine, which is handy to test out all the features.

``` ruby
$geoip.city("127.0.0.1")
# => nil

$geoip.local_ip = "173.194.112.35"

$geoip.city("127.0.0.1") 
# => #<struct GeoIP::City request="localhost", ip="173.194.112.35", country_code2="US", country_code3="USA", country_name="United States", continent_code="NA", region_name="CA", city_name="Mountain View", postal_code="94043", latitude=37.41919999999999, longitude=-122.0574, dma_code=807, area_code=650, timezone="America/Los_Angeles">
```
