### PR TITLE
Update license to match README

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Jeweler::Tasks.new do |gem|
   gem.name = "geoip"
   gem.version = GeoIP::VERSION
   gem.homepage = "http://github.com/cjheath/geoip"
-  gem.license = "GPL"
+  gem.license = "LGPL"
   gem.summary = %Q{GeoIP searches a GeoIP database for a given host or IP address, and returns information about the country where the IP address is allocated, and the city, ISP and other information, if you have that database version.}
   gem.description = %Q{GeoIP searches a GeoIP database for a given host or IP address, and
 returns information about the country where the IP address is allocated,


### PR DESCRIPTION
Apply clarification made to the README to the gem configuration - the gemspec will also need to be updated, but that should happen during next release.
