### PR TITLE
Update timezone for CAON (Canada/Ontario)

### DIFF
--- a/data/geoip/time_zone.yml
+++ b/data/geoip/time_zone.yml
@@ -530,7 +530,7 @@ MM: Asia/Rangoon
 RU65: Europe/Samara
 RU18: Asia/Krasnoyarsk
 BR17: America/Recife
-CAON: America/Rainy_River
+CAON: America/Toronto
 MN: Asia/Choibalsan
 RU66: Europe/Moscow
 BR18: America/Sao_Paulo


### PR DESCRIPTION
Changing the timezone for CAON (Canada/Ontario) to America/Toronto. The previous timezone (America/Rainy_River) corresponds to Central Time, when in reality most of Ontario is in Eastern Time. This is still not 100% accurate, since Ontario crosses 2 timezones, but it is probably 95% accurate based on population.

If you look at the maxmind/geoip-api-c repo, you will see the same change has been made.
