### PR TITLE
Add #to_hash method to GeoIP::ASN for consistency

### DIFF
--- a/lib/geoip.rb
+++ b/lib/geoip.rb
@@ -148,6 +148,10 @@ class GeoIP
 
     alias as_num number
 
+    def to_hash
+      Hash[each_pair.to_a]
+    end
+
   end
 
   # The Edition number that identifies which kind of database you've opened


### PR DESCRIPTION
It's nice to have all structs respond to `#to_hash`.
