### PR TITLE
Make things Copy-on-write friendly

### DIFF
--- a/lib/geoip.rb
+++ b/lib/geoip.rb
@@ -171,17 +171,16 @@ class GeoIP
   # Open the GeoIP database and determine the file format version.
   #
   # +filename+ is a String holding the path to the GeoIP.dat file
-  # +flags+ is an integer holding caching flags (unimplemented)
-  # +options+ is a Hash allowing you to specify the preload option
+  # +options+ is a Hash allowing you to specify the caching options
   #
-  def initialize(filename, flags = 0, options = {})
+  def initialize(filename, options = {})
     if options[:preload] || !IO.respond_to?(:pread)
       @mutex = Mutex.new
     end
 
     @use_pread = IO.respond_to?(:pread) && !options[:preload]
 
-    @flags = flags
+    @options = options
     @database_type = GEOIP_COUNTRY_EDITION
     @record_length = STANDARD_RECORD_LENGTH
     @file = File.open(filename, 'rb')


### PR DESCRIPTION
This adds an optional parameter to preload the geoip database into a StringIO which is copy-on-write friendly for forked processes.

For high-concurrency unicorn environments running ruby 2.0 or higher this can save large amounts of memory. In the case of [Shopify](https://github.com/Shopify) this saves up to 2.6GB per worker (30 processes with 90MB per process).

I haven't tested situations where `io/extra` has been included, but it appears to be the correct syntax for it so it should work.

@cjheath
