### PR TITLE
remove Rakefile from the packaging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ and the city, ISP and other information, if you have that database version.}
   # and development dependencies are only needed for development (ie running rake tasks, tests, etc)
   #  gem.add_runtime_dependency 'jabber4r', '> 0.1'
   #  gem.add_development_dependency 'rspec', '> 1.2.3'
-  gem.files.exclude "website/**/*.*", "script/*", "config/*"
+  gem.files.exclude "Rakefile", "website/**/*.*", "script/*", "config/*"
 end
 Jeweler::RubygemsDotOrgTasks.new
 

--- a/geoip.gemspec
+++ b/geoip.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
     "History.rdoc",
     "LICENSE",
     "README.rdoc",
-    "Rakefile",
     "bin/geoip",
     "data/geoip/country_code.yml",
     "data/geoip/country_code3.yml",


### PR DESCRIPTION
Normal Gem users to not need this file, so we can stop shipping it in the gem package that gets published to rubygems.org.