### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Jeweler::Tasks.new do |gem|
   # gem is a Gem::Specification... see http://docs.rubygems.org/read/chapter/20 for more options
   gem.name = "geoip"
   gem.version = GeoIP::VERSION
-  gem.homepage = "http://github.com/cjheath/geoip"
+  gem.homepage = "https://github.com/cjheath/geoip"
   gem.license = "LGPL"
   gem.summary = %Q{GeoIP searches a GeoIP database for a given host or IP address, and returns information about the country where the IP address is allocated, and the city, ISP and other information, if you have that database version.}
   gem.description = %Q{GeoIP searches a GeoIP database for a given host or IP address, and


### PR DESCRIPTION
This reduces an unneeded redirection from `http://...` to `https://...` when someone visits this gem's homepage via https://rubygems.org/gems/geoip