### PR TITLE
fix ISP name encoding

### DIFF
--- a/lib/geoip.rb
+++ b/lib/geoip.rb
@@ -734,6 +734,7 @@ class GeoIP
   def read_isp offset
     record = atomic_read(MAX_ORG_RECORD_LENGTH, index_size+offset)
     record = record.sub(/\000.*/n, '')
+    record = record.force_encoding('iso-8859-1').encode('utf-8') if record.respond_to?(:force_encoding)
     record.start_with?('*') ? nil : ISP.new(record)
   end
 


### PR DESCRIPTION
Similar to the other fields, ISP name is encoded in `iso-8869-1`, but Ruby takes it as utf-8 by default.

Example output:
```
# with patch
irb(main):004:0* GeoIP.new('GeoIPOrg.dat').isp('177.10.45.46')
=> #<struct GeoIP::ISP isp="Informatica e Telecomunicações LTDA">

# without patch
irb(main):002:0> GeoIP.new('GeoIPOrg.dat').isp('177.10.45.46')
=> #<struct GeoIP::ISP isp="Informatica e Telecomunica\xE7\xF5es LTDA">
```